### PR TITLE
Added recipe for Santis

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ cd handsOn
 make COMPILER=nvidia TARGET=gpu handsOn1
 srun -n 1 --partition=debug --nodes=1 --time=0:05:00  ./handsOn1/handsOn1
 ```
+# Compile and run on Santis
+```console
+uenv start --view=modules icon/25.2:v1
+module load nvhpc
+cd handsOn
+make COMPILER=nvidia TARGET=gpu handsOn1
+srun -n 1 --partition=debug --nodes=1 --time=0:05:00  ./handsOn1/handsOn1
+
 for profiling
 ```console
 srun -n 1 --partition=debug --nodes=1 --time=0:05:00 nsys profile --trace openacc --output nsys-profile --cuda-memory-usage true ./example_openacc4/example_openacc4

--- a/handsOn/Makefile
+++ b/handsOn/Makefile
@@ -20,7 +20,7 @@ ifeq ($(COMPILER),nvidia)
  FC=nvfortran
  LD=$(FC)
  ifeq ($(TARGET),gpu) 
-  FFLAGS=-O3 -Mpreprocess -gpu=cc80 -acc=verystrict -Minfo=acceel
+  FFLAGS=-O3 -Mpreprocess -gpu=cc80 -acc=verystrict -Minfo=accel
   LFLAGS=-gpu=cc80 -acc=verystrict -cuda
  else
   FFLAGS=-O3 -Mpreprocess -mp


### PR DESCRIPTION
This adds the recipe for running the OpenACC training on Santis to the README.md.

There is also a small correction for a typo in the Makefile.